### PR TITLE
Add elaboration menus.

### DIFF
--- a/gtlc/editor/Elaborate.esv
+++ b/gtlc/editor/Elaborate.esv
@@ -1,0 +1,8 @@
+module Elaborate
+
+menus
+
+  menu: "Elaborate" (openeditor)
+
+    action: "Elaborate source AST" = menu-source-elaborate (source)
+    action: "Elaborate analyzed AST" = menu-analyzed-elaborate

--- a/gtlc/editor/Main.esv
+++ b/gtlc/editor/Main.esv
@@ -4,6 +4,7 @@ imports
 
   Syntax
   Analysis
+  Elaborate
 
 language
 

--- a/gtlc/trans/analysis.str
+++ b/gtlc/trans/analysis.str
@@ -5,7 +5,7 @@ imports
   statixruntime
 
   pp
-  
+
   signatures/gtlc-sig
 
 rules // Analysis

--- a/gtlc/trans/elaborate.str
+++ b/gtlc/trans/elaborate.str
@@ -1,0 +1,27 @@
+module elaborate
+
+imports
+
+  signatures/-
+
+  analysis
+
+  statixruntime
+
+rules
+
+  menu-analyzed-elaborate:
+      (analyzed-ast, _, _, path, project-path) -> (filename, elaborated-ast)
+    with
+      filename := <guarantee-extension(|"elaborated.aterm")> path
+    ; elaborated-ast := <elaborate> analyzed-ast
+
+  menu-source-elaborate:
+      (source-ast, _, _, path, project-path) -> (filename, elaborated-ast)
+    with
+      filename := <guarantee-extension(|"elaborated.aterm")> path
+    ; desugared-ast := <desugar-all;stx-index-ast(|path)> source-ast
+    ; analyzed-ast := <stx-evaluate(|"static-semantics", "insertCasts")> [desugared-ast]
+    ; elaborated-ast := <elaborate> analyzed-ast
+
+  elaborate = id

--- a/gtlc/trans/gtlc.str
+++ b/gtlc/trans/gtlc.str
@@ -6,6 +6,7 @@ imports
   pp
   outline
   analysis
+  elaborate
 
 rules // Debugging
   


### PR DESCRIPTION
This is an example of menus calling Statix for elaboration. I've included two versions. One based assuming that the elaborating analysis is used. The menu takes the analyzed AST and transforms them further. The other works on the source and is not dependent on any particular analysis. It calls Statix to evaluate the constraint and capture the result, which is then further transformed.

Building and running this code requires changes that will be included in the next nightly build -- available hopefully in a a few hours.